### PR TITLE
Resolução da issue 'Imprimir versão Radar #245'

### DIFF
--- a/radar_parlamentar/radar_parlamentar/models.py
+++ b/radar_parlamentar/radar_parlamentar/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/radar_parlamentar/radar_parlamentar/templates/base.html
+++ b/radar_parlamentar/radar_parlamentar/templates/base.html
@@ -296,8 +296,13 @@
             </div><!-- end of .wrap -->
         </div><!-- end of .top -->
         <section class="bottom">
+            
             <div class="contents">
-                <p class="copy">Copyright &copy; 2012 | <a href="http://www.gnu.org/licenses/agpl">Alguns Direitos Reservados: Affero GPL</a> | <a href="https://github.com/leonardofl/radar_parlamentar">Código Fonte deste projeto</a></p>
+                <p class="copy">
+                    Copyright &copy; 2012 | 
+					<a href="http://www.gnu.org/licenses/agpl">Alguns Direitos Reservados: Affero GPL</a> | 
+                    <a href="https://github.com/leonardofl/radar_parlamentar">Código Fonte deste projeto</a> 
+				</p>
                 <ul class="socialLinks">
                     <li class="twitter"><a href="https://twitter.com/#!/RadarParlamento">Twitter</a></li>
                     <li class="facebook"><a href="https://www.facebook.com/RadarParlamentar">Facebook</a></li>
@@ -306,6 +311,11 @@
                     <li class="flickr"><a href="#">Flickr</a></li> -->
 
                 </ul><!-- end of socialLinks -->
+                
+                <p class="version">
+                    {% load versao_radar %}
+                    {% versao_radar %}
+                </p> <!-- end of version -->
             </div><!-- end of .contents -->
         </section><!-- end of .bottom -->
     </footer><!-- end of #footer -->

--- a/radar_parlamentar/radar_parlamentar/templatetags/versao_radar.py
+++ b/radar_parlamentar/radar_parlamentar/templatetags/versao_radar.py
@@ -1,0 +1,27 @@
+# -*- coding: utf8 -*-
+
+import subprocess
+import settings
+from django import template
+register = template.Library()
+import logging
+
+logger = logging.getLogger("radar")
+
+@register.simple_tag
+def versao_radar():
+    time_zone = settings.defaults.TIME_ZONE
+    versao_radar = ''
+
+    try:
+        cmd_data_ultimo_commit = 'TZ={0} date -d @$(git log -n1 --format="%at") "+%d/%m/%Y"'.format(time_zone)
+        data_ultimo_commit = subprocess.check_output(cmd_data_ultimo_commit, shell=True)
+
+        cmd_hash_ultimo_commit = 'git log --pretty=format:"%h" -n 1'
+        hash_ultimo_commit = subprocess.check_output(cmd_hash_ultimo_commit, shell=True)
+
+        versao_radar = 'Versão: <a href="https://github.com/radar-parlamentar/radar/commit/{0}">{0}</a> de {1}'.format(hash_ultimo_commit, data_ultimo_commit)
+    except subprocess.CalledProcessError, e:
+        logger.error('Erro ao pegar o hash ou a data do ultimo commit (versao sera omitida)')
+
+    return versao_radar

--- a/radar_parlamentar/radar_parlamentar/tests.py
+++ b/radar_parlamentar/radar_parlamentar/tests.py
@@ -1,0 +1,15 @@
+# -*- coding: utf8 -*-
+
+from django.test import TestCase
+from radar_parlamentar.templatetags.versao_radar import versao_radar
+import re
+
+class VersaoRadarTest(TestCase):
+    def setUp(self):
+        self.versao_radar = versao_radar()
+        
+    def test_versao_radar(self):
+        pattern = r'^Versão: <a href="https://github.com/radar-parlamentar/radar/commit/[a-z0-9]{7}">[a-z0-9]{7}</a> de \d{2}/\d{2}/\d{4}$'
+        result = re.match(pattern, self.versao_radar)
+        
+        self.assertIsNotNone(result)

--- a/radar_parlamentar/settings/defaults.py
+++ b/radar_parlamentar/settings/defaults.py
@@ -121,7 +121,7 @@ INSTALLED_APPS = (
     'importadorInterno',
     'testes_integracao',
     'south',
-
+    'radar_parlamentar',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/radar_parlamentar/static/files/codes/css/style.css
+++ b/radar_parlamentar/static/files/codes/css/style.css
@@ -1227,15 +1227,24 @@ ol.list.alphalow{list-style: lower-alpha;}
             width: 980px;
         }
 
-            #footer .copy{
+        #footer .copy{
                 float: left;
                 font-size: 11px;
-                margin: 10px 40px 10px 0;
+                margin: 10px 40px 0 0;
                 width: 470px;
             }
+            
+        #footer .version {
+            font-size: 11px;
+            margin-top: 30px;
+        }
 
+            #footer .version a:focus,
+            #footer .version a:hover,
             #footer .copy a:focus,
-            #footer .copy a:hover{color: #444;}
+            #footer .copy a:hover {
+                color: #444;
+            }
 
             #footer .socialLinks{
                 float: left;

--- a/radar_parlamentar/unit_tests.sh
+++ b/radar_parlamentar/unit_tests.sh
@@ -1,1 +1,1 @@
-python manage.py test modelagem analises exportadores importadorInterno importadores
+python manage.py test -v 2 modelagem analises exportadores importadorInterno importadores radar_parlamentar


### PR DESCRIPTION
Para resolver a issue #245 foi criado um templatetag para imprimir a versão do radar, isso para não ser necessário colocar no context de todas as views a versão do radar... 
A URL de referência ao GitHub foi inserida no código Python para não haver necessidade de verificação no template se a versão foi encontrada ou não, assim caso aconteça algum erro somente será inserida no HTML uma string vazia.
Para realizar um teste unitário foi necessário incluir o app 'radar_parlamentar' no settings e também criar um módulo models.py.