### PR TITLE
Corrigindo link com a versão do radar

### DIFF
--- a/radar_parlamentar/radar_parlamentar/templatetags/versao_radar.py
+++ b/radar_parlamentar/radar_parlamentar/templatetags/versao_radar.py
@@ -16,12 +16,13 @@ def versao_radar():
     try:
         cmd_data_ultimo_commit = 'TZ={0} date -d @$(git log -n1 --format="%at") "+%d/%m/%Y"'.format(time_zone)
         data_ultimo_commit = subprocess.check_output(cmd_data_ultimo_commit, shell=True)
-
-        cmd_hash_ultimo_commit = 'git log --pretty=format:"%h" -n 1'
+        
+        cmd_hash_ultimo_commit = 'git log --pretty=format:"%H" -n 1'
         hash_ultimo_commit = subprocess.check_output(cmd_hash_ultimo_commit, shell=True)
-
-        versao_radar = 'Versão: <a href="https://github.com/radar-parlamentar/radar/commit/{0}">{0}</a> de {1}'.format(hash_ultimo_commit, data_ultimo_commit)
-    except subprocess.CalledProcessError, e:
+        hash_abrev_ultimo_commit = hash_ultimo_commit[:7]
+        
+        versao_radar = 'Versão: <a href="https://github.com/radar-parlamentar/radar/commit/{0}" target="_blank">{1}</a> de {2}'.format(hash_ultimo_commit, hash_abrev_ultimo_commit, data_ultimo_commit)
+    except (IndexError, subprocess.CalledProcessError) as e:
         logger.error('Erro ao pegar o hash ou a data do ultimo commit (versao sera omitida)')
 
     return versao_radar

--- a/radar_parlamentar/radar_parlamentar/tests.py
+++ b/radar_parlamentar/radar_parlamentar/tests.py
@@ -9,7 +9,8 @@ class VersaoRadarTest(TestCase):
         self.versao_radar = versao_radar()
         
     def test_versao_radar(self):
-        pattern = r'^Versão: <a href="https://github.com/radar-parlamentar/radar/commit/[a-z0-9]{7}">[a-z0-9]{7}</a> de \d{2}/\d{2}/\d{4}$'
+        pattern = r'^Versão: <a href="https://github\.com/radar-parlamentar/radar/commit/[a-z0-9]{40}".*>[a-z0-9]{7}</a> de \d{2}/\d{2}/\d{4}$'
+        
         result = re.match(pattern, self.versao_radar)
         
         self.assertIsNotNone(result)


### PR DESCRIPTION
'Adicionando o hash completo do commit no link da versão e colocando o target para _blank'

Nem sempre a URL com o hash abreviado (7 primeiros caracteres) consegue ser resolvida no GitHub, então agora a URL é composta pelo hash completo.