### PR TITLE
Resolvendo a issue "Limitar tamanho do log #117"

### DIFF
--- a/radar_parlamentar/settings/defaults.py
+++ b/radar_parlamentar/settings/defaults.py
@@ -156,11 +156,13 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
         },
-        'file':{
+    'file': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'simple',
-            'filename': 'radar.log'
+            'filename': 'radar.log',
+            'backupCount': 2,
+            'maxBytes': 1024*1024*10, # 10MB
         }
     },
     'loggers': {


### PR DESCRIPTION
Issue #117: Foi inserido um RotatingFileHandler para limitar o arquivo radar.log (limite de tamanho de 10MB e com no máximo 2 backups)