### PR TITLE
Analise pca periodica #227

### DIFF
--- a/radar_parlamentar/cron/cache-analises.sh
+++ b/radar_parlamentar/cron/cache-analises.sh
@@ -1,3 +1,32 @@
 #!/bin/bash
 # invoca rotinas de análise para que os resultados fiquem guardados no cache
-curl http://localhost/analises/json_analise/cmsp/BIENIO/
+
+nome_script=`basename "$0"`
+
+echo "Iniciando a execucao do '$nome_script' em '$(date)'"
+inicio=$(date '+%s')
+
+periodicidades=("QUADRIENIO" "BIENIO" "ANO" "SEMESTRE")
+casas_legislativas=("cmsp" "cdep" "sen")
+
+for casa in ${casas_legislativas[*]}; do
+    for periodicidade in ${periodicidades[*]}; do
+        url="http://localhost/analises/json_analise/$casa/$periodicidade/"
+        echo "Executando o curl para $url"
+        curl --fail --silent --show-error $url > /dev/null
+        
+        rc=$?
+        if [[ $rc != 0 ]]; then
+            echo "Erro executando o curl para $url"
+        fi
+    done
+done
+
+fim=$(date '+%s')
+dt=$((fim - inicio))
+ds=$((dt % 60))
+dm=$(((dt / 60) % 60))
+dh=$((dt / 3600))
+
+echo "Terminando a execucao do '$nome_script' em '$(date)'."
+printf "Se passaram %dh %02dmin %02ds\n\n" $dh $dm $ds

--- a/radar_parlamentar/cron/cache-analises.sh
+++ b/radar_parlamentar/cron/cache-analises.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
-# invoca rotinas de análise para que os resultados fiquem guardados no cache
-
-nome_script=`basename "$0"`
-
-echo "Iniciando a execucao do '$nome_script' em '$(date)'"
-inicio=$(date '+%s')
+# Invoca rotinas de análise para que os resultados fiquem guardados no cache
 
 periodicidades=("QUADRIENIO" "BIENIO" "ANO" "SEMESTRE")
 casas_legislativas=("cmsp" "cdep" "sen")
+porta_development=8000
+
+if [[ "$DJANGO_SETTINGS_MODULE" == "settings.development" ]]; then
+	base_url="http://localhost:$porta_development"
+else
+	base_url="http://localhost"
+fi
+
+echo "Iniciando a rotina de cache das analises em '$(date)'"
+inicio=$(date '+%s')
 
 for casa in ${casas_legislativas[*]}; do
     for periodicidade in ${periodicidades[*]}; do
-        url="http://localhost/analises/json_analise/$casa/$periodicidade/"
-        echo "Executando o curl para $url"
+        url="$base_url/analises/json_analise/$casa/$periodicidade/"
+        echo "curl $url"
         curl --fail --silent --show-error $url > /dev/null
         
         rc=$?
@@ -28,5 +33,5 @@ ds=$((dt % 60))
 dm=$(((dt / 60) % 60))
 dh=$((dt / 3600))
 
-echo "Terminando a execucao do '$nome_script' em '$(date)'."
+echo "Finalizando a rotina de cache das analises em '$(date)'."
 printf "Se passaram %dh %02dmin %02ds\n\n" $dh $dm $ds

--- a/radar_parlamentar/cron/clear-cache.sh
+++ b/radar_parlamentar/cron/clear-cache.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+
+echo -e "Limpando o cache do radar"
 sudo rm -rf /tmp/django_cache/*

--- a/radar_parlamentar/cron/crontab
+++ b/radar_parlamentar/cron/crontab
@@ -34,7 +34,7 @@
 # ss = dia_da_semana(0-6)
 
 SHELL=/bin/bash
-0 1 * * * clear-cache.sh; source cache-analises.sh >> /var/log/radar/radar-cron.log 2>>&1
+0 1 * * * { $SHELL clear-cache.sh && $SHELL cache-analises.sh; } >> /var/log/radar/radar-cron.log 2>&1
 0 4 * * 0 source ~/.profile; source dump-radar.sh >> /var/log/radar/radar-cron.log 2>>&1
 
 


### PR DESCRIPTION
Criação do script que faz o acesso aos gráficos PCA de todas as casas em todos os períodos (se o cache tiver ativado, tudo vai ficar em cache).
Alteração do script cron. Fix #227