### PR TITLE
Alteração do estilo de fonte

### DIFF
--- a/radar_parlamentar/static/files/codes/css/radar_d3_graph.css
+++ b/radar_parlamentar/static/files/codes/css/radar_d3_graph.css
@@ -105,7 +105,7 @@
 }
 
 .year.label {
-    font: 500 50px "Helvetica Neue";
+    font: 500 40px "Arial";
     fill: #bbb;
     transition: all 0.5s;
     -moz-transition: all 0.5s;


### PR DESCRIPTION
Pesquisando sobre essa issue descobrimos que é normal haver diferença entre os browsers porque eles renderizam a fonte de forma diferente. Nesse caso, diminuímos o impacto dessa diferença alterando a fonte para Arial. #162 