### PR TITLE
Compactando o dump da base de dados com bz2

### DIFF
--- a/radar_parlamentar/cron/dump-radar.sh
+++ b/radar_parlamentar/cron/dump-radar.sh
@@ -2,3 +2,4 @@
 # Argumento: arquivo de saída (onde o dump será salvo)
 echo "Gerando dump completo do banco em '$(date)'"
 pg_dump -h localhost -U radar radar --inserts -t modelagem_* -f $1
+bzip2 -9 $1


### PR DESCRIPTION
FIX #295 
@leonardofl, acho que é isso né?
Só temos que lembrar de mudar o link que está na página HTML que direciona para o DUMP, acho que está hardcoded e ai vai linkar para uma versão "não compactada" que não vai mais existir.