### PR TITLE
Retirando links sociais da barra superior

### DIFF
--- a/radar_parlamentar/radar_parlamentar/templates/base.html
+++ b/radar_parlamentar/radar_parlamentar/templates/base.html
@@ -134,12 +134,6 @@
     <section id="content">
         <ul class="breadcrumbs">
             {% block breadcrumbs %}{% endblock breadcrumbs %} 
-              <span class='st_fbsend_hcount' displayText='Facebook Send'></span>
-              <span class='st_fblike_hcount' displayText='Facebook Like'></span>
-              <span class='st_twitter_hcount' displayText='Tweet'></span>
-              <span class='st_plusone_hcount' displayText='Google +1'></span>
-              <span class='st_identi_hcount' displayText='identi.ca'></span>
-              <span class='st_reddit_hcount' displayText='Reddit'></span>
         </ul>
         {% if messages %}
             <ul class="messages">


### PR DESCRIPTION
Foi retirado os links sociais da barra superior Fix #297 