### PR TITLE
Tagcloud

### DIFF
--- a/radar_parlamentar/analises/genero.py
+++ b/radar_parlamentar/analises/genero.py
@@ -17,23 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Radar Parlamentar.  If not, see <http://www.gnu.org/licenses/>.
 
-# import sys
-# sys.path.insert(0, '/radar/radar_parlamentar/modelagem')
-# sys.path.append('/radar/radar_parlamentar/modelagem/models.py')
-
 from modelagem.models import CasaLegislativa, Parlamentar, Proposicao
-
-# from radar.radar_parlamentar.modelagem.models import
-# from modelagem.models import modelagem
-# from modelagem.models import CasaLegislativa
 
 
 class Genero:
 
     @staticmethod
-    def definir_palavras(genero):
+    def definir_palavras(genero, id_casa_legislativa):
         temas = []
-        for parlamentar in Parlamentar.objects.filter(genero=genero):
+        for parlamentar in Parlamentar.objects.filter(genero=genero, casa_legislativa_id=id_casa_legislativa):
             for proposicao in Proposicao.objects.filter(
                     autor_principal=parlamentar.nome):
                 for tema in proposicao.indexacao.split(','):

--- a/radar_parlamentar/analises/genero.py
+++ b/radar_parlamentar/analises/genero.py
@@ -17,8 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Radar Parlamentar.  If not, see <http://www.gnu.org/licenses/>.
 
-from modelagem.models import Proposicao
-from modelagem.models import Parlamentar
+# import sys
+# sys.path.insert(0, '/radar/radar_parlamentar/modelagem')
+# sys.path.append('/radar/radar_parlamentar/modelagem/models.py')
+
+from modelagem.models import CasaLegislativa, Parlamentar, Proposicao
+
+# from radar.radar_parlamentar.modelagem.models import
+# from modelagem.models import modelagem
+# from modelagem.models import CasaLegislativa
 
 
 class Genero:
@@ -46,3 +53,21 @@ class Genero:
         temas_frequencia = temas_frequencia[:51]
 
         return temas_frequencia
+
+
+    '''
+    Retorna as casas legislativas que tenham parlamentares com a informacao de genero
+    '''
+    @staticmethod
+    def get_casas_legislativas_com_genero():
+
+        casas_legislativas = []
+
+        for casa in CasaLegislativa.objects.all():
+            for parlamentar in Parlamentar.objects.filter(casa_legislativa_id=casa.id):
+                if parlamentar.genero != "":
+                    casas_legislativas.append(casa)
+                    break
+
+        return casas_legislativas
+

--- a/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
+++ b/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
@@ -31,34 +31,42 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
+
      <article id="descricao" class="inwrap">
-        O objetivo deste projeto é fazer uma análise gráfica da participação de deputadas e deputados na Câmara Federal.<br/>
-        É propósito observar as participações feminina e masculina na casa legislativa, seja do ponto de vista quantitativo, seja do ponto de vista qualitativo.<br/>
+        O objetivo deste projeto é fazer uma análise gráfica da participação de parlamentares em suas casas legislativas.<br/>
+        Para isso, tem-se a intenção de observar as participações feminina e masculina na casa legislativa, tanto do ponto de vista quantitativo, quanto do ponto de vista qualitativo.<br/>
         <h4 style="margin-bottom:5px;">O que é este gráfico?</h4>
         <aside id="como-funciona" style="margin: 0 90px 10px 20px; padding: 10px; background-color: rgba(220,220,220,0.7); -webkit-border-radius: 20px; -moz-border-radius: 20px; border-radius: 20px;">
         Trata-se de uma visualização de dados <b>nuvem de palavras</b> em que são apresentadas as 150 palavras temáticas mais frequentes nas indexações de proposições legislativas para cada um dos gêneros. No primeiro gráfico temos as palavras mais recorrentes nas indexações das proposições apresentadas por mulheres enquanto no segundo as palavras mais recorrentes nas indexações de proposições apresentadas por homens.<br/>
         </aside>
         Analise as frequências de temas por Gênero e tire suas próprias conclusões.<br/>
-    
+
         <!--Quantidade de palavras-chave consideradas nesta análise: <b>33</b> palavras.<br/><br/>
         Quantidade de partidos consideradas nesta análise: <b>75</b> partidos.<br/><br/-->
         Os dados da Câmara dos Deputados utilizados para análise estão disponíveis para <a href="https://github.com/radar-parlamentar/radar">download aqui</a>.<br/>
-         <form id="formTagCloud"  method="get" action="genero_tagcloud.html">
-             <p><label for="casa_legislativa"> Casa Legislativa: </label>
-                 <select id="casa_legislativa" name="casas_legislativas_list">
+         <form id="formTagCloud"  method="get" action="" onloadstart="teste()">
+             <p><label for="casa_legislativa_list"> Casa Legislativa: </label>
+                 <select id="casa_legislativa_list" name="casa_legislativa" onchange="enableButton()">
                      <option value="" selected="selected"> Selecione... </option>
                      {% for casa in casas_legislativas %}
                          <option value="{{casa.id}}"> {{ casa.nome }} </option>
                      {% endfor %}
                  </select>
              </p>
-         <input type="submit" value="gerar_tag_cloud" title="Gerar nuvem de palavras!">
+         <input id="button" type="submit" value="Gerar nuvem de palavras!" title="Gerar nuvem de palavras!" disabled="disabled" >
          </form>
-        <h4>Mulheres</h4>
-        <div id="tagcloud_mulher">
-        </div>
-        <h4>Homens</h4>
-        <div id="tagcloud_homem">
+
+        {% if temas_mulher and temas_homem %}
+        <div id="tagCloudSpan" style="visibility: visible">
+        {% else  %}
+        <div id="tagCloudSpan" style="visibility: hidden">
+        {% endif %}
+            <h4>Mulheres</h4>
+            <div id="tagcloud_mulher">
+            </div>
+            <h4>Homens</h4>
+            <div id="tagcloud_homem">
+            </div>
         </div>
     </article>
         <div style="clear:right"/>
@@ -158,6 +166,27 @@
 {% endblock extrajsend %}
 
 {% block extrascriptsend %}
+
+    setOptionAfterPageLoad();
+
+    function setOptionAfterPageLoad() {
+        var combobox = document.getElementById("casa_legislativa_list");
+        var url = window.location.href;
+        var idcasa = /casa_legislativa=([^&]+)/.exec(url)[1];
+        combobox.value = idcasa;
+    }
+
+    function enableButton() {
+        var combobox = document.getElementById("casa_legislativa_list");
+        var selectedVal = combobox.value;
+
+        if (Number(selectedVal)===parseInt(selectedVal) && !(selectedVal=="")) {
+            var button = document.getElementById("button").removeAttribute('disabled');
+        } else {
+            var button = document.getElementById("button").addAttribute('disabled');
+        }
+    }
+
     menuActive("genero");
     $(document).ready(function() {
     });

--- a/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
+++ b/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
@@ -47,8 +47,8 @@
              <p><label for="casa_legislativa"> Casa Legislativa: </label>
                  <select id="casa_legislativa" name="casas_legislativas_list">
                      <option value="" selected="selected"> Selecione... </option>
-                     {% for casa in casas %}
-                         <option value="{{casa.id}}"> {{ casa.nome|capfirst }} </option>
+                     {% for casa in casas_legislativas %}
+                         <option value="{{casa.id}}"> {{ casa.nome }} </option>
                      {% endfor %}
                  </select>
              </p>

--- a/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
+++ b/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
@@ -37,13 +37,13 @@
         Para isso, tem-se a intenção de observar as participações feminina e masculina na casa legislativa, tanto do ponto de vista quantitativo, quanto do ponto de vista qualitativo.<br/>
         <h4 style="margin-bottom:5px;">O que é este gráfico?</h4>
         <aside id="como-funciona" style="margin: 0 90px 10px 20px; padding: 10px; background-color: rgba(220,220,220,0.7); -webkit-border-radius: 20px; -moz-border-radius: 20px; border-radius: 20px;">
-        Trata-se de uma visualização de dados <b>nuvem de palavras</b> em que são apresentadas as 150 palavras temáticas mais frequentes nas indexações de proposições legislativas para cada um dos gêneros. No primeiro gráfico temos as palavras mais recorrentes nas indexações das proposições apresentadas por mulheres enquanto no segundo as palavras mais recorrentes nas indexações de proposições apresentadas por homens.<br/>
+        Trata-se de uma visualização de dados <b>nuvem de palavras</b> em que são apresentadas as 50 palavras temáticas mais frequentes nas indexações de proposições legislativas para cada um dos gêneros. No primeiro gráfico temos as palavras mais recorrentes nas indexações das proposições apresentadas por mulheres enquanto no segundo as palavras mais recorrentes nas indexações de proposições apresentadas por homens.<br/>
         </aside>
         Analise as frequências de temas por Gênero e tire suas próprias conclusões.<br/>
 
         <!--Quantidade de palavras-chave consideradas nesta análise: <b>33</b> palavras.<br/><br/>
         Quantidade de partidos consideradas nesta análise: <b>75</b> partidos.<br/><br/-->
-        Os dados da Câmara dos Deputados utilizados para análise estão disponíveis para <a href="https://github.com/radar-parlamentar/radar">download aqui</a>.<br/>
+        Os dados das casas legislativas utilizados para análise estão disponíveis para <a href="https://github.com/radar-parlamentar/radar">download aqui</a>.<br/>
          <form id="formTagCloud"  method="get" action="" onloadstart="teste()">
              <p><label for="casa_legislativa_list"> Casa Legislativa: </label>
                  <select id="casa_legislativa_list" name="casa_legislativa" onchange="enableButton()">

--- a/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
+++ b/radar_parlamentar/radar_parlamentar/templates/genero_tagcloud.html
@@ -42,8 +42,18 @@
     
         <!--Quantidade de palavras-chave consideradas nesta análise: <b>33</b> palavras.<br/><br/>
         Quantidade de partidos consideradas nesta análise: <b>75</b> partidos.<br/><br/-->
-        Os dados da Câmara dos Deputados utilizados para análise estão disponíveis para <a href="https://github.com/radar-parlamentar/radar">download aqui</a>.<br/>    
-
+        Os dados da Câmara dos Deputados utilizados para análise estão disponíveis para <a href="https://github.com/radar-parlamentar/radar">download aqui</a>.<br/>
+         <form id="formTagCloud"  method="get" action="genero_tagcloud.html">
+             <p><label for="casa_legislativa"> Casa Legislativa: </label>
+                 <select id="casa_legislativa" name="casas_legislativas_list">
+                     <option value="" selected="selected"> Selecione... </option>
+                     {% for casa in casas %}
+                         <option value="{{casa.id}}"> {{ casa.nome|capfirst }} </option>
+                     {% endfor %}
+                 </select>
+             </p>
+         <input type="submit" value="gerar_tag_cloud" title="Gerar nuvem de palavras!">
+         </form>
         <h4>Mulheres</h4>
         <div id="tagcloud_mulher">
         </div>

--- a/radar_parlamentar/radar_parlamentar/urls.py
+++ b/radar_parlamentar/radar_parlamentar/urls.py
@@ -61,6 +61,8 @@ urlpatterns = patterns(
         'radar_parlamentar.views.genero_futuro'),
     url(r'^genero/tematica/nuvem/$',
         'radar_parlamentar.views.genero_termos_nuvem'),
+    url(r'^genero/tematica/nuvem/?Pcasa_legislativa=$',
+        'radar_parlamentar.views.genero_termos_nuvem'),
 
     # Serviço que retorna conteúdo para plotar o mapa
     url(r'^' + url_analise + casa_legislativa + '$',

--- a/radar_parlamentar/radar_parlamentar/views.py
+++ b/radar_parlamentar/radar_parlamentar/views.py
@@ -77,19 +77,34 @@ def genero(request):
 
 
 def genero_termos_nuvem(request):
+
     genero = Genero()
-    temas_frequencia_mulher = genero.definir_palavras('F')
-    # logger.info("Temasdamulher %s" % (temas_frequencia_mulher))
-    temas_json_mulher = json.dumps(temas_frequencia_mulher)
-    temas_frequencia_homem = genero.definir_palavras('M')
-    temas_json_homem = json.dumps(temas_frequencia_homem)
+
     casas_legislativas_com_genero = genero.get_casas_legislativas_com_genero()
 
-    return render_to_response('genero_tagcloud.html',
+    try:
+        id_casa_legislativa = int(request.GET["casa_legislativa"])
+    except:
+        id_casa_legislativa = ""
+
+    if not isinstance(id_casa_legislativa, int):
+
+        return render_to_response('genero_tagcloud.html',
+                                  {'casas_legislativas': casas_legislativas_com_genero},
+                                  context_instance=RequestContext(request))
+
+    else:
+        temas_frequencia_mulher = genero.definir_palavras('F', id_casa_legislativa)
+        # logger.info("Temasdamulher %s" % (temas_frequencia_mulher))
+        temas_json_mulher = json.dumps(temas_frequencia_mulher)
+        temas_frequencia_homem = genero.definir_palavras('M', id_casa_legislativa)
+        temas_json_homem = json.dumps(temas_frequencia_homem)
+
+        return render_to_response('genero_tagcloud.html',
                               {'temas_mulher': temas_json_mulher,
                                'temas_homem': temas_json_homem,
                                'casas_legislativas' : casas_legislativas_com_genero},
-                              context_instance=RequestContext(request))
+                               context_instance=RequestContext(request))
 
 
 def genero_matriz(request):

--- a/radar_parlamentar/radar_parlamentar/views.py
+++ b/radar_parlamentar/radar_parlamentar/views.py
@@ -83,10 +83,12 @@ def genero_termos_nuvem(request):
     temas_json_mulher = json.dumps(temas_frequencia_mulher)
     temas_frequencia_homem = genero.definir_palavras('M')
     temas_json_homem = json.dumps(temas_frequencia_homem)
+    casas_legislativas_com_genero = genero.get_casas_legislativas_com_genero()
 
     return render_to_response('genero_tagcloud.html',
                               {'temas_mulher': temas_json_mulher,
-                               'temas_homem': temas_json_homem},
+                               'temas_homem': temas_json_homem,
+                               'casas_legislativas' : casas_legislativas_com_genero},
                               context_instance=RequestContext(request))
 
 


### PR DESCRIPTION
Pull request relativo a issue https://github.com/radar-parlamentar/radar/issues/315

https://github.com/MES-1-2016/radar/issues/20

A funcionalidade foi implementada levando em conta as casas legislativas que possuem os dados de gênero de seus parlamentares. Ou seja, apenas as casas que possuem essas informações teram a opção de gerar a nuvem de palavras. Contudo, ao passo que o dado de gênero dos parlametnares  de determinada casa for inserido no banco, a opção de gerar a nuvem de palavras para a casa em questão também aparecerá.