### PR TITLE
Conserta o shbang do manage.py

### DIFF
--- a/radar_parlamentar/manage.py
+++ b/radar_parlamentar/manage.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
Sabe quando vc roda `./manage.py runserver` e aparece um cursor diferente na sua
tela? Isso é conseqüência do shbang quebrad. Aquela primeira linha do manage.py
não pode ter espaço. Se o shbang estiver correto, ele vai rodar o script com
python. Com ele quebrado, ele roda shell e acaba executando o comando `import` (que tira 
screenshots e muda o cursor...).