### PR TITLE
Templates do django admin não são encontrados nos pips modernos

### DIFF
--- a/radar_parlamentar/requirements.txt
+++ b/radar_parlamentar/requirements.txt
@@ -1,3 +1,4 @@
+--no-binary Django # source install allows template loading in older django installs
 Django==1.4.5
 psycopg2==2.5.4
 argparse==1.2.1


### PR DESCRIPTION
O pip moderno cria wheels (binários) antes de instalar. Isso complica o django quando ele quer procurar os arquivos de template. O parâmetro `--no-binary` resolve isso.

http://stackoverflow.com/questions/31009216/my-django-installs-in-virtual-env-are-missing-admin-templates-folder
https://github.com/pypa/pip/issues/2823
