### PR TITLE
Issue-#441: Adição do link para plenária na lista de votações filtradas

### DIFF
--- a/radar_parlamentar/radar_parlamentar/templates/lista_de_votacoes_filtradas.html
+++ b/radar_parlamentar/radar_parlamentar/templates/lista_de_votacoes_filtradas.html
@@ -37,7 +37,11 @@
 
     {% for votacao in votacoes %}
         <tr>
-            <td align="justify">{{votacao.proposicao.sigla}}{{votacao.proposicao.numero}}/{{votacao.proposicao.ano}}</td>
+			<td align="justify">
+				<a href="/plenaria/{{casa_legislativa.nome_curto}}/{{votacao.proposicao.sigla}}-{{votacao.proposicao.numero}}-{{votacao.proposicao.ano}}/">
+					{{votacao.proposicao.sigla}}{{votacao.proposicao.numero}}/{{votacao.proposicao.ano}}
+				</a>
+			</td>
             <td align="justify"><b>{{votacao.data}} </br></b>{{votacao.descricao}}</td>
             <td align="justify">{{votacao.proposicao.ementa}}</td>
             <td align="justify">{{votacao.proposicao.indexacao}}</td>


### PR DESCRIPTION
O link ficou como demonstrado na imagem a seguir:

![screenshot from 2018-05-10 16-39-47](https://user-images.githubusercontent.com/11580667/39890386-2025057e-548a-11e8-8893-fd9f468d57dc.png)

Co-authored-by: Felipe <felipe.osorio72@outlook.com.br>
Co-authored-by: Gustavo Lopes <gustavo.ldbrito@gmail.com>